### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()


### PR DESCRIPTION
Adding `Jenkinsfile` as requested in [hosting instructions](https://issues.jenkins-ci.org/browse/HOSTING-1034).

>In order for your plugin to be built by the Jenkins CI Infrastructure and check pull requests, please add a Jenkinsfile to the root of your repository with the following content:
> ```buildPlugin()```