### PR TITLE
Add concurrent suite execution

### DIFF
--- a/src/main/java/com/ghostinspector/jenkins/GhostInspector/GhostInspectorBuilder.java
+++ b/src/main/java/com/ghostinspector/jenkins/GhostInspector/GhostInspectorBuilder.java
@@ -1,26 +1,29 @@
 package com.ghostinspector.jenkins.GhostInspector;
 
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.Secret;
+import jenkins.tasks.SimpleBuildStep;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import hudson.EnvVars;
-import hudson.Launcher;
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.model.*;
-import hudson.model.AbstractProject;
-import hudson.tasks.Builder;
-import hudson.tasks.BuildStepDescriptor;
-import hudson.util.Secret;
-import jenkins.tasks.SimpleBuildStep;
-import javax.annotation.Nonnull;
-import org.jenkinsci.Symbol;
-import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * GhostInspectorBuilder {@link Builder}.
@@ -97,13 +100,14 @@ public class GhostInspectorBuilder extends Builder implements SimpleBuildStep {
     }
 
     logger.println(DISPLAY_NAME);
-    logger.println("Suite ID: " + expandedSuiteId);
+    logger.println("Suite ID(s): " + expandedSuiteId);
     logger.println("Start URL: " + expandedStartUrl);
     logger.println("Additional Parameters: " + expandedParams);
 
+    List<TestSuite> testSuiteList = TestSuite.buildFromCommaSeparatedList(expandedSuiteId);
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     Future<String> future = executorService.submit(
-        new GhostInspectorTrigger(logger, expandedApiKey, expandedSuiteId, expandedStartUrl, expandedParams));
+        new GhostInspectorTrigger(logger, expandedApiKey, testSuiteList, expandedStartUrl, expandedParams));
 
     try {
       String result = future.get(TIMEOUT + 30, TimeUnit.SECONDS);

--- a/src/main/java/com/ghostinspector/jenkins/GhostInspector/GhostInspectorTrigger.java
+++ b/src/main/java/com/ghostinspector/jenkins/GhostInspector/GhostInspectorTrigger.java
@@ -1,24 +1,26 @@
 package com.ghostinspector.jenkins.GhostInspector;
 
+import hudson.util.Secret;
+import net.sf.json.JSONObject;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.util.EntityUtils;
+
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import hudson.util.Secret;
-
-import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.impl.nio.client.HttpAsyncClients;
-
-import net.sf.json.JSONObject;
+import static com.ghostinspector.jenkins.GhostInspector.TestSuite.Status.*;
 
 /**
  * GhostInspectorTrigger
@@ -27,30 +29,91 @@ public class GhostInspectorTrigger implements Callable<String> {
 
   private static final String API_HOST = "https://api.ghostinspector.com";
   private static final String API_VERSION = "v1";
-  private static final String TEST_RESULTS_PENDING = "pending";
   private static final String TEST_RESULTS_PASS = "pass";
   private static final String TEST_RESULTS_FAIL = "fail";
 
   private final Secret apiKey;
-  private final String suiteId;
+  private final List<TestSuite> testSuiteList;
   private final String startUrl;
   private final String params;
 
   private PrintStream log;
 
-  public GhostInspectorTrigger(PrintStream logger, String apiKey, String suiteId, String startUrl, String params) {
+  public GhostInspectorTrigger(PrintStream logger, String apiKey, List<TestSuite> testSuiteList, String startUrl, String params) {
     this.log = logger;
     this.apiKey = Secret.fromString(apiKey);
-    this.suiteId = suiteId;
+    this.testSuiteList = testSuiteList;
     this.startUrl = startUrl;
     this.params = params;
   }
 
   @Override
   public String call() throws Exception {
-    String result = null;
+
+    //populate URLs and ResultID for each test suite
+    for (TestSuite ts : testSuiteList) {
+
+      setExecuteUrl(ts);
+
+      ts.setResultId( parseResultId(fetchUrl(ts.getExecuteUrl())));
+      log.println("Suite triggered. Result ID received: " + ts.getResultId());
+
+      ts.setResultUrl(API_HOST + "/" + API_VERSION + "/suite-results/" + ts.getResultId() + "/?apiKey=" + apiKey.getPlainText());
+    }
+
+
+    // Poll suite result until it completes
+    while (true) {
+      // Sleep for 10 seconds
+      try {
+        TimeUnit.SECONDS.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+
+      for (TestSuite ts : testSuiteList) {
+        if (isSuiteComplete(ts)) {
+          continue;
+        }
+        ts.setStatus(parseResult(ts.getSuiteId(), fetchUrl(ts.getResultUrl())));
+        if (isSuiteComplete(ts)) {
+          log.println("Suite ID: " + ts.getSuiteId() + " has completed.");
+        }
+      }
+
+      int suitesCompleted = countSuitesCompleted();
+      if (suitesCompleted == testSuiteList.size()) {
+        return getAllSuiteResult();
+      }
+      else {
+        log.println("Suite(s) are still in progress. " +
+                    "Completed " + suitesCompleted + " of " + testSuiteList.size() +
+                    ". Checking again in 10 seconds...");
+      }
+    }
+  }
+
+  /**
+   *  Look at all test suites, if one has failed, return fail
+   * @return test suite status
+   */
+  private String getAllSuiteResult() {
+    for (TestSuite ts : testSuiteList) {
+      if (ts.getStatus() == COMPLETE_FAIL) {
+        return TEST_RESULTS_FAIL;
+      }
+    }
+    return TEST_RESULTS_PASS;
+  }
+
+  /**
+   *  Set the execute URL on a single Test Suite Model
+   * @param ts
+   * @throws UnsupportedEncodingException
+   */
+  private void setExecuteUrl(TestSuite ts) throws UnsupportedEncodingException {
     // Generate suite execution API URL
-    String executeUrl = API_HOST + "/" + API_VERSION + "/suites/" + suiteId + "/execute/?immediate=1";
+    String executeUrl = API_HOST + "/" + API_VERSION + "/suites/" + ts.getSuiteId() + "/execute/?immediate=1";
     if (startUrl != null && !startUrl.isEmpty()) {
       executeUrl = executeUrl + "&startUrl=" + URLEncoder.encode(startUrl, "UTF-8");
     }
@@ -60,29 +123,31 @@ public class GhostInspectorTrigger implements Callable<String> {
     log.println("Suite Execution URL: " + executeUrl);
 
     // Add API key after URL is logged
-    executeUrl = executeUrl + "&apiKey=" + apiKey.getPlainText();
+    ts.setExecuteUrl(executeUrl + "&apiKey=" + apiKey.getPlainText());
+  }
 
-    // Trigger suite and fetch result ID
-    String resultId = parseResultId(fetchUrl(executeUrl));
-    log.println("Suite triggered. Result ID received: " + resultId);
-
-    // Poll suite result until it completes
-    String resultUrl = API_HOST + "/" + API_VERSION + "/suite-results/" + resultId + "/?apiKey=" + apiKey.getPlainText();
-    while (true) {
-      // Sleep for 10 seconds
-      try {
-        TimeUnit.SECONDS.sleep(10);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-      // Check result
-      result = parseResult(fetchUrl(resultUrl));
-      if (result == TEST_RESULTS_PENDING) {
-        log.println("Suite is still in progress. Checking again in 10 seconds...");
-      } else {
-        return result;
+  /**
+   * Test to see if ALL suites have completed running, regardless of pass/fail
+   * @return true if ALL suites have completed, false otherwise
+   */
+  private int countSuitesCompleted() {
+    int count = 0;
+    for (TestSuite tsm : testSuiteList) {
+      if (isSuiteComplete(tsm)) {
+        count++;
       }
     }
+    return count;
+  }
+
+  /**
+   * Test to see if suite has completed running, regardless of pass / fail
+   * @param ts
+   * @return true if complete, false otherwise
+   */
+  private boolean isSuiteComplete(TestSuite ts) {
+    return ts.getStatus() == COMPLETE_PASS ||
+           ts.getStatus() == COMPLETE_FAIL;
   }
 
   /**
@@ -145,22 +210,23 @@ public class GhostInspectorTrigger implements Callable<String> {
    * @param data The JSON to parse in string format
    * @return The status of the suite result
    */
-  private String parseResult(String data) {
+  private TestSuite.Status parseResult(String suiteId, String data) {
     JSONObject jsonObject = JSONObject.fromObject(data);
     JSONObject result = jsonObject.getJSONObject("data");
 
     if (result.get("passing").toString().equals("null")) {
-      return TEST_RESULTS_PENDING;
+      return PENDING;
     }
 
+    log.println("Suite ID: " + suiteId);
     log.println("Test runs passed: " + result.get("countPassing"));
     log.println("Test runs failed: " + result.get("countFailing"));
     log.println("Execution time: " + (Integer.parseInt(result.get("executionTime").toString()) / 1000) + " seconds");
 
     if (result.get("passing").toString().equals("true")) {
-      return TEST_RESULTS_PASS;
+      return COMPLETE_PASS;
     } else {
-      return TEST_RESULTS_FAIL;
+      return COMPLETE_FAIL;
     }
   }
 

--- a/src/main/java/com/ghostinspector/jenkins/GhostInspector/TestSuite.java
+++ b/src/main/java/com/ghostinspector/jenkins/GhostInspector/TestSuite.java
@@ -1,0 +1,88 @@
+package com.ghostinspector.jenkins.GhostInspector;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Holder class for all suites to be run, each entry from comma separated entered list will create one instance
+ */
+public class TestSuite {
+
+  private String suiteId, resultId;
+
+  private String executeUrl, resultUrl;
+
+  private Status status;
+
+  enum Status {
+    PENDING,
+    COMPLETE_PASS,
+    COMPLETE_FAIL
+  }
+
+  /**
+   * Creates a Test Suite with default status
+   * @param suiteId one suite ID from input list
+   */
+  public TestSuite(String suiteId) {
+    this.suiteId = suiteId;
+    this.status = Status.PENDING;
+  }
+
+  /**
+   * @param suiteList this list of suite IDs input from the UI
+   * @return populated test suites with opening Status of PENDING, empty list if suiteList is null or empty
+   */
+  public static List<TestSuite> buildFromCommaSeparatedList(String suiteList) {
+    if (suiteList == null || suiteList.isEmpty()) {
+      return Collections.emptyList();
+    }
+    //remove all whitespace
+    suiteList = suiteList.replaceAll("\\s+","");
+    List<String> suiteStringList = Arrays.asList(suiteList.split("\\,"));
+
+    List<TestSuite> testSuiteList = new ArrayList<>();
+    for (String suiteId : suiteStringList) {
+      testSuiteList.add(new TestSuite(suiteId));
+    }
+    return testSuiteList;
+  }
+
+  public String getSuiteId() {
+    return suiteId;
+  }
+
+  public String getResultId() {
+    return resultId;
+  }
+
+  public void setResultId(String resultId) {
+    this.resultId = resultId;
+  }
+
+  public String getExecuteUrl() {
+    return executeUrl;
+  }
+
+  public void setExecuteUrl(String executeUrl) {
+    this.executeUrl = executeUrl;
+  }
+
+  public String getResultUrl() {
+    return resultUrl;
+  }
+
+  public void setResultUrl(String resultUrl) {
+    this.resultUrl = resultUrl;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public void setStatus(Status status) {
+    this.status = status;
+  }
+}

--- a/src/main/resources/com/ghostinspector/jenkins/GhostInspector/GhostInspectorBuilder/help-suiteId.html
+++ b/src/main/resources/com/ghostinspector/jenkins/GhostInspector/GhostInspectorBuilder/help-suiteId.html
@@ -1,3 +1,3 @@
 <div>
-  Enter the ID of the Ghost Inpsector suite that you would like to execute.
+  Enter the ID of the Ghost Inspector suite that you would like to execute. For more than one Suite, add Suite IDs separated by a comma. Each Suite ID will use the same Start URL and Params. All Suites will be run concurrently.
 </div>


### PR DESCRIPTION
Currently, only one Suite ID can be added to a standard Jenkins "Post Build Step". Multiple build steps are required to execute multiple Suites, these build steps are executed consecutively.

This PR allows multiple suite IDs to be added to one build step (comma separated list), the UI fields in Jenkins remain the same. 

The "Suite ID" field allows entry of a comma-separated list, with each suite being executed concurrently. A single Suite ID still works.

