### PR TITLE
Get rid of the problem with bad type of apiKey variable

### DIFF
--- a/.project
+++ b/.project
@@ -22,12 +22,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1615413506489</id>
+			<id>1668528759296</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/src/main/java/com/ghostinspector/jenkins/GhostInspector/GhostInspectorBuilder.java
+++ b/src/main/java/com/ghostinspector/jenkins/GhostInspector/GhostInspectorBuilder.java
@@ -30,7 +30,8 @@ public class GhostInspectorBuilder extends Builder implements SimpleBuildStep {
   private static final int TIMEOUT = 36000;
   private SuiteExecutionConfig config;
 
-  private final Secret apiKey;
+  private final String apiKey;
+  private final Secret apiKeySecret;
   private final String suiteId;
   private final String startUrl;
   private final String params;
@@ -38,7 +39,8 @@ public class GhostInspectorBuilder extends Builder implements SimpleBuildStep {
   @DataBoundConstructor
   public GhostInspectorBuilder(String apiKey, String suiteId, String startUrl, String params) {
     // store these for display in Jenkins
-    this.apiKey = Secret.fromString(apiKey);
+    this.apiKey = apiKey;
+    this.apiKeySecret = Secret.fromString(apiKey);
     this.suiteId = suiteId;
     this.startUrl = startUrl;
     this.params = params;
@@ -48,7 +50,7 @@ public class GhostInspectorBuilder extends Builder implements SimpleBuildStep {
   /**
    * @return the apiKey
    */
-  public Secret getApiKey() {
+  public String getApiKey() {
     return apiKey;
   }
 
@@ -81,7 +83,7 @@ public class GhostInspectorBuilder extends Builder implements SimpleBuildStep {
     Logger.setLogger(listener.getLogger());
 
     // set up initial configuration for execution
-    config = new SuiteExecutionConfig(apiKey, suiteId, startUrl, params);
+    config = new SuiteExecutionConfig(apiKeySecret, suiteId, startUrl, params);
     config.applyVariables(build.getEnvironment(listener));
 
     // report our status before we start

--- a/src/main/java/com/ghostinspector/jenkins/GhostInspector/SuiteExecutionConfig.java
+++ b/src/main/java/com/ghostinspector/jenkins/GhostInspector/SuiteExecutionConfig.java
@@ -13,9 +13,9 @@ public class SuiteExecutionConfig {
   public final List<String> suiteIds;
   public final UrlFactory urls;
 
-  public SuiteExecutionConfig(Secret apiKey, String rawIdString, String startUrl, String params) {
+  public SuiteExecutionConfig(Secret apiKeySecret, String rawIdString, String startUrl, String params) {
     this.suiteIds = parseIds(rawIdString);
-    this.urls = new UrlFactory(apiKey, startUrl, params);
+    this.urls = new UrlFactory(apiKeySecret, startUrl, params);
   }
 
   public void applyVariables(EnvVars variables) {

--- a/src/main/java/com/ghostinspector/jenkins/GhostInspector/UrlFactory.java
+++ b/src/main/java/com/ghostinspector/jenkins/GhostInspector/UrlFactory.java
@@ -13,19 +13,19 @@ public class UrlFactory {
 
   private String startUrl;
   private String urlParams;
-  private Secret apiKey;
+  private Secret apiKeySecret;
   private PrintStream logger;
 
 
-  public UrlFactory(Secret apiKey, String startUrl, String urlParams) {
-    this.apiKey = apiKey;
+  public UrlFactory(Secret apiKeySecret, String startUrl, String urlParams) {
+    this.apiKeySecret = apiKeySecret;
     this.startUrl = startUrl;
     this.urlParams = urlParams;
   }
 
   public void expandVariables(EnvVars envVars) {
-    if (apiKey != null) {
-      apiKey = Secret.fromString(envVars.expand(apiKey.getPlainText()));
+    if (apiKeySecret != null) {
+      apiKeySecret = Secret.fromString(envVars.expand(apiKeySecret.getPlainText()));
     }
 
     if (startUrl != null && !startUrl.isEmpty()) {
@@ -55,15 +55,15 @@ public class UrlFactory {
   }
 
   public String getExecuteSuiteUrl(String suiteId) {
-    return apiRoot + "/suites/" + suiteId + "/execute" + buildQueryString() + "&apiKey=" + apiKey.getPlainText();
+    return apiRoot + "/suites/" + suiteId + "/execute" + buildQueryString() + "&apiKey=" + apiKeySecret.getPlainText();
   }
 
   public String getSafeExecuteSuiteUrl(String suiteId) {
-    return apiRoot + "/suites/" + suiteId + "/execute" + buildQueryString() + "&apiKey=" + apiKey.getPlainText().substring(0, 4) + "xxx";
+    return apiRoot + "/suites/" + suiteId + "/execute" + buildQueryString() + "&apiKey=" + apiKeySecret.getPlainText().substring(0, 4) + "xxx";
   }
 
   public String getSuiteResultUrl(String resultId) {
-    return apiRoot + "/suite-results/" + resultId + "?apiKey=" + apiKey.getPlainText();
+    return apiRoot + "/suite-results/" + resultId + "?apiKey=" + apiKeySecret.getPlainText();
   }
 
   public String getUrlParams() {


### PR DESCRIPTION
# Description

It is fix for that issue:

> 2022-11-17 10:10:15.463+0000 [id=183764]	WARNING	o.j.p.s.d.DescribableModel#uninstantiate2: Cannot create control version of class org.jenkinsci.plugins.workflow.steps.CoreStep using {delegate=@ghostInspector$GhostInspectorBuilder(apiKey=${GI_API_KEY},startUrl=https://url/v2/,suiteId=5f563fe5f9d41d44b7dc8346)}
java.lang.ClassCastException: com.ghostinspector.jenkins.GhostInspector.GhostInspectorBuilder.apiKey expects **class java.lang.String** but received class **hudson.util.Secret**
Caused: java.lang.IllegalArgumentException: Could not instantiate {apiKey=${GI_API_KEY}, startUrl=url/, suiteId=5f563fe5f9d41d44b7dc8346} for com.ghostinspector.jenkins.GhostInspector.GhostInspectorBuilder
Caused: java.lang.IllegalArgumentException: Could not instantiate {delegate=@ghostInspector$GhostInspectorBuilder(apiKey=${GI_API_KEY},startUrl=https://url/,suiteId=5f563fe5f9d41d44b7dc8346)} for org.jenkinsci.plugins.workflow.steps.CoreStep

Communication with Ghost Inspector works fine. But there are many WARNING logs in the jenkins everytime when it tries to connect to the Ghost Inspector. Somehow jenkins is changing apiKey variable which is String at the beginning to the Secret type and it causes that problem.

The proposal is to create apiKeySecret field to not override apiKey String variable.

