### PR TITLE
Ghost Inspector Builder step doesn't throw any error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 Ghost Inspector Plugin for Jenkins
 -------------
 ### Build status:


### PR DESCRIPTION
I don't know how to create an issue in this repository or it is just maybe not allowed.

So I've created PR with dummy change.

**ISSUE DESCRIPTION:**

Currently, after GhostInspectorBuilder step is finished in jenkins and it is failed, step is marked as success.
I see that only build result is set to false - https://github.com/jenkinsci/ghost-inspector-plugin/blob/1e1fbcf28f009d3bf2683dea3c4e89b3ad7a66f5/src/main/java/com/ghostinspector/jenkins/GhostInspector/GhostInspectorBuilder.java#L98

In our pipeline we run sequentially multiple stages for GI. Every stage run another test suite.

We have in our pipeline a check `if (currentBuild.result == 'FAILURE')` (which is set by GI step) and then we run `error()`. So the stage is marked as red in jenkins. That was working until I've added a change to not stop a build when one of test suite fail with using `catchError` function in Jenkins.

Because of my change, now if some test suite fails next test suites will be also marked as failed (even if they passed) because of that check `if (currentBuild.result == 'FAILURE')` which is also true for next GI stages.

I've tried somehow to workaround it but I don't have any more ideas and I think one possible solution is to fix behavior of `GhostInspectorBuilder` class. For me it is a bug and I think the class should throw an error when a test suite fails. 






